### PR TITLE
Rename Eject.Ejectable to Eject.File

### DIFF
--- a/lib/eject.ex
+++ b/lib/eject.ex
@@ -234,9 +234,9 @@ defmodule Eject do
     IO.write(IO.ANSI.clear_line() <> "\r📂 #{app.destination}")
     File.mkdir_p!(app.destination)
 
-    for ejectable <- Eject.Ejectable.all_for_app(app) do
+    for ejectable <- Eject.File.all_for_app(app) do
       IO.write(IO.ANSI.clear_line() <> "\r💾 [#{ejectable.type}] #{ejectable.destination}")
-      Eject.Ejectable.eject!(ejectable, app)
+      Eject.File.eject!(ejectable, app)
     end
 
     IO.puts("")

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Eject.MixProject do
       groups_for_modules: [
         "Ejectable Apps": [
           Eject.App,
-          Eject.Ejectable,
+          Eject.File,
           Eject.Manifest
         ],
         Transformation: [


### PR DESCRIPTION
There are essentially two meanings to "Ejectable" before this PR: "an app that can be ejected", and "a file or directory to eject".

The latter concept is renamed to a `File`.