### PR TITLE
Remove warning and match dotfiles in compiled templates

### DIFF
--- a/lib/uniform/blueprint.ex
+++ b/lib/uniform/blueprint.ex
@@ -7,25 +7,24 @@ defmodule Uniform.Blueprint.BeforeCompile do
       if templates_dir do
         templates_dir
         |> Path.join("**/*.eex")
-        |> Path.wildcard()
+        |> Path.wildcard(match_dot: true)
       else
         []
       end
 
     template_functions =
       for path <- templates do
+        quoted = EEx.compile_file(path)
         path = Path.relative_to(path, templates_dir)
 
         quote do
           @file unquote(path)
           @external_resource unquote(path)
 
-          EEx.function_from_file(
-            :def,
-            unquote(String.to_atom(path)),
-            unquote(Path.join(templates_dir, path)),
-            [:app]
-          )
+          def unquote(String.to_atom(path))(var!(app)) do
+            _ = var!(app)
+            unquote(quoted)
+          end
         end
       end
 


### PR DESCRIPTION
I should have tested `v0.5.0` against our codebase more thoroughly before publishing. There were 2 issues:

1. Templates starting with `.` could no longer be used
2. During `mix uniform.eject`, you'd receive a warning for any template that didn't use `app`:

```
warning: variable "app" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/my_base_app/uniform/templates/path/to/template.eex:1: MyBaseApp.Uniform.Blueprint."path/to/template.eex"/1
```

To fix (1), we now pass `match_dot: true` to `Path.wildcard` when searching for templates to compile.

To fix (2), we [mimic Phoenix.View](https://github.com/phoenixframework/phoenix_view/blob/79ed7e428270f7b150c71990d92302db34f2672f/lib/phoenix/template.ex#L426-L429) by manually creating the function and doing `_ = var!(app)` to remove the warning, instead of using `EEx.function_from_file`.