### PR TITLE
Support eject fences for comment types with a suffix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,19 @@ on:
 jobs:
   ci:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         include:
           - elixir: 1.10.4
-            otp: 21.3.8.24
+            otp: 21.0
           - elixir: 1.11.4
-            otp: 23.2
+            otp: 23.0
           - elixir: 1.12.3
-            otp: 24.1
+            otp: 24.0
           - elixir: 1.13.0
-            otp: 24.1
+            otp: 24.0
           - elixir: 1.14.0
             otp: 25.0
             check_formatted: true

--- a/guides/introduction/Code Transformations.md
+++ b/guides/introduction/Code Transformations.md
@@ -168,6 +168,9 @@ end
 
 # eject fences for Rust files
 modify ~r/\.rs$/, &eject_fences(&1, &2, "//")
+
+# eject fences for CSS files
+modify ~r/\.css$/, &eject_fences(&1, &2, "/\\*", "\\*/")
 ```
 
 ## Disabling Code Transformations

--- a/lib/uniform/blueprint.ex
+++ b/lib/uniform/blueprint.ex
@@ -356,7 +356,7 @@ defmodule Uniform.Blueprint do
 
       import Uniform.Blueprint, only: [modify: 2, deps: 1, base_files: 1]
       import Uniform.App, only: [depends_on?: 3]
-      import Uniform.Modifiers, only: [eject_fences: 3]
+      import Uniform.Modifiers, only: [eject_fences: 3, eject_fences: 4]
       require EEx
 
       Module.register_attribute(__MODULE__, :lib_deps, accumulate: true)

--- a/lib/uniform/modifiers.ex
+++ b/lib/uniform/modifiers.ex
@@ -39,7 +39,12 @@ defmodule Uniform.Modifiers do
       end
 
   """
-  @spec eject_fences(String.t(), Uniform.App.t(), prefix :: String.t(), suffix :: String.t()) ::
+  @spec eject_fences(
+          String.t(),
+          Uniform.App.t(),
+          prefix :: String.t(),
+          suffix :: String.t() | nil
+        ) ::
           String.t()
   def eject_fences(file_contents, app, prefix, suffix \\ nil) do
     remove_regex =

--- a/lib/uniform/modifiers.ex
+++ b/lib/uniform/modifiers.ex
@@ -8,7 +8,7 @@ defmodule Uniform.Modifiers do
   # Eject Fences
   #
 
-  @doc """
+  @doc ~S"""
   Apply [Eject Fences](code-transformations.html#eject-fences) to extra
   languages with this function.
 

--- a/test/uniform/modifiers_test.exs
+++ b/test/uniform/modifiers_test.exs
@@ -47,7 +47,7 @@ defmodule Uniform.ModifiersTest do
     assert output =~ "Keep"
     refute output =~ "Remove"
     # code fences themselves are always removed
-    refute output =~ "eject"
+    refute output =~ "uniform"
   end
 
   test "uniform:mix", %{app: app} do
@@ -69,7 +69,7 @@ defmodule Uniform.ModifiersTest do
     assert output =~ "Keep"
     refute output =~ "Remove"
     # code fences themselves are always removed
-    refute output =~ "eject"
+    refute output =~ "uniform"
   end
 
   test "uniform:app", %{app: app} do
@@ -95,7 +95,7 @@ defmodule Uniform.ModifiersTest do
     assert output =~ "Keep"
     refute output =~ "Remove"
     # code fences themselves are always removed
-    refute output =~ "eject"
+    refute output =~ "uniform"
   end
 
   test "uniform:remove", %{app: app} do
@@ -115,6 +115,46 @@ defmodule Uniform.ModifiersTest do
     assert output =~ "Keep"
     refute output =~ "Remove"
     # code fences themselves are always removed
-    refute output =~ "eject"
+    refute output =~ "uniform"
+  end
+
+  test "comment suffixes", %{app: app} do
+    output =
+      Modifiers.eject_fences(
+        """
+        p {text-color: "red"}
+
+        /* uniform:remove */
+        h1 {text-color: "blue"}
+        /* /uniform:remove */
+        """,
+        app,
+        "/\\*",
+        "\\*/"
+      )
+
+    assert output =~ "red"
+    refute output =~ "blue"
+    # code fences themselves are always removed
+    refute output =~ "uniform"
+  end
+
+  test "js_eject_fences", %{app: app} do
+    output =
+      Modifiers.js_eject_fences(
+        """
+        console.log(true + true - true);
+
+        // uniform:remove
+        console.log(0.1 + 0.2);
+        // /uniform:remove
+        """,
+        app
+      )
+
+    assert output =~ "true"
+    refute output =~ "0.1"
+    # code fences themselves are always removed
+    refute output =~ "uniform"
   end
 end


### PR DESCRIPTION
This PR adds support for Eject fences for languages without a single-line comment style with only a prefix.

For example, while SQL allows you to comment a line by prefixing with `--`:

```sql
-- Some SQL comment
```

The only available CSS comment syntax requires a suffix as well:

```css
/* Some CSS comment */
```
