### PR TITLE
fix app.extra formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           cd test/projects/empty && mix deps.get && mix compile
           cd ../full && mix deps.get && mix compile
           cd ../initable && mix deps.get && mix compile
+          cd ../extra_formatting && mix deps.get && mix compile
           cd ../missing_template && mix deps.get && mix compile
           cd ../missing_template_dir && mix deps.get && mix compile
       - run: mix compile --warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1 (2026-04-22)
+
+  * Fix formatting of large `app.extra` output in `mix uniform.eject` (#49)
+
 ## v0.6.0 (2023-02-06)
 
   * Adds support for suffix on eject fences (#46)

--- a/guides/introduction/Getting Started.md
+++ b/guides/introduction/Getting Started.md
@@ -7,7 +7,7 @@ Add `:uniform` as a dependency in `mix.exs`.
 ```elixir
 defp deps do
   [
-    {:uniform, "~> 0.6.0"}
+    {:uniform, "~> 0.6.1"}
   ]
 end
 ```

--- a/lib/mix/tasks/uniform.eject.ex
+++ b/lib/mix/tasks/uniform.eject.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Uniform.Eject do
       IO.puts("📰 Extra:")
 
       app.extra
-      |> inspect()
+      |> inspect(limit: :infinity, printable_limit: :infinity)
       |> Code.format_string!()
       |> to_string()
       |> String.replace(~r/^/m, "   ")

--- a/lib/uniform/lib_dep.ex
+++ b/lib/uniform/lib_dep.ex
@@ -35,6 +35,7 @@ defmodule Uniform.LibDep do
       %Uniform.LibDep{
         always: true,
         associated_files: ["priv/path/to/associated/file"],
+        except: nil,
         only: nil,
         lib_deps: [:my_graph_dep],
         mix_deps: [:absinthe],

--- a/lib/uniform/lib_dep.ex
+++ b/lib/uniform/lib_dep.ex
@@ -30,13 +30,11 @@ defmodule Uniform.LibDep do
       ...>   lib_deps: [:my_graph_dep],
       ...>   always: true,
       ...>   only: nil,
-      ...>   except: [~r/regex-of-files-not-to-eject/],
       ...>   associated_files: ["priv/path/to/associated/file"],
       ...> })
       %Uniform.LibDep{
         always: true,
         associated_files: ["priv/path/to/associated/file"],
-        except: [~r/regex-of-files-not-to-eject/],
         only: nil,
         lib_deps: [:my_graph_dep],
         mix_deps: [:absinthe],

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Uniform.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
   @source_url "https://github.com/ucbi/uniform"
 
   def project do

--- a/test/mix/tasks/uniform.eject_test.exs
+++ b/test/mix/tasks/uniform.eject_test.exs
@@ -15,6 +15,15 @@ defmodule Mix.Tasks.Uniform.EjectTest do
     {_, 0} = eject("empty", "hatmail")
   end
 
+  test "ejecting with a large extra payload does not abbreviate inspected code" do
+    {stdout, 0} = eject("extra_formatting", "newsflash")
+
+    assert stdout =~ "📰 Extra:"
+    assert stdout =~ "archive_tag: :community"
+    assert stdout =~ "TAIL_MARKER"
+    refute stdout =~ "..."
+  end
+
   test "missing templates directory" do
     {stderr, 1} = eject("missing_template_dir", "trillo")
 
@@ -148,7 +157,7 @@ defmodule Mix.Tasks.Uniform.EjectTest do
     args = [
       "run",
       "-e",
-      "Uniform.ejectable_apps() |> hd() |> Map.delete(:__struct__) |> inspect() |> IO.puts()"
+      "Uniform.ejectable_apps() |> hd() |> Map.delete(:__struct__) |> inspect(limit: :infinity, printable_limit: :infinity) |> IO.puts()"
     ]
 
     {stdout, 0} = System.cmd("mix", args, cd: "test/projects/#{project}")

--- a/test/projects/extra_formatting/.formatter.exs
+++ b/test/projects/extra_formatting/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/test/projects/extra_formatting/config/config.exs
+++ b/test/projects/extra_formatting/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+# uniform:remove
+config :extra_formatting, Uniform, blueprint: ExtraFormatting.Uniform.Blueprint
+# /uniform:remove

--- a/test/projects/extra_formatting/lib/extra_formatting/uniform/blueprint.ex
+++ b/test/projects/extra_formatting/lib/extra_formatting/uniform/blueprint.ex
@@ -1,0 +1,3 @@
+defmodule ExtraFormatting.Uniform.Blueprint do
+  use Uniform.Blueprint
+end

--- a/test/projects/extra_formatting/lib/newsflash/uniform.exs
+++ b/test/projects/extra_formatting/lib/newsflash/uniform.exs
@@ -1,0 +1,91 @@
+[
+  extra: [
+    theme: :acme,
+    web_module: NewsflashWeb,
+    sync_to_remote: true,
+    long_note: String.duplicate("breaking-news-", 350) <> "TAIL_MARKER",
+    edition_layouts: [
+      homepage: [
+        lead_story_slots: 3,
+        secondary_story_slots: 6,
+        photo_gallery_slots: 1,
+        newsletter_promos: 2,
+        podcast_highlights: 1,
+        trending_topics: 5,
+        local_weather_panel: true,
+        market_watch_panel: true,
+        corrections_banner: true
+      ],
+      morning_briefing: [
+        hero_story_slots: 1,
+        roundup_story_slots: 8,
+        opinion_slots: 2,
+        data_visualizations: 1,
+        quote_cards: 3,
+        sponsor_spots: 1,
+        push_alert_recaps: true,
+        audio_briefing_embed: true,
+        archive_linkouts: true
+      ],
+      weekend_review: [
+        feature_story_slots: 4,
+        culture_story_slots: 4,
+        sports_story_slots: 4,
+        long_reads: 6,
+        photo_essays: 2,
+        columnists: 5,
+        crossword_teaser: true,
+        events_calendar: true,
+        subscriber_perks: true
+      ]
+    ],
+    desk_policies: [
+      investigations: [
+        fact_check_rounds: 3,
+        legal_review: :required,
+        correction_window: :permanent,
+        photo_style: :documentary,
+        audio_teaser: true,
+        newsletter_slot: :front_page,
+        archive_snapshot: :weekly,
+        social_card_variant: :serious,
+        reader_tipline: :enabled
+      ],
+      politics: [
+        fact_check_rounds: 2,
+        legal_review: :as_needed,
+        correction_window: :permanent,
+        photo_style: :wire,
+        audio_teaser: true,
+        newsletter_slot: :morning_briefing,
+        archive_snapshot: :daily,
+        social_card_variant: :standard,
+        reader_tipline: :enabled
+      ],
+      culture: [
+        fact_check_rounds: 1,
+        legal_review: :rare,
+        correction_window: :permanent,
+        photo_style: :feature,
+        audio_teaser: false,
+        newsletter_slot: :weekend_review,
+        archive_snapshot: :weekly,
+        social_card_variant: :bold,
+        reader_tipline: :disabled
+      ]
+    ],
+    reader_programs: [
+      subscriber_q_and_a: [
+        cadence: :weekly,
+        host: :city_editor,
+        transcript: true,
+        replay_window: {30, :days},
+        spotlight_rotation: :manual,
+        comments: :subscriber_only,
+        signup_flow: :inline,
+        theme: :newsroom_blue,
+        archive_tag: :community
+      ]
+    ]
+  ]
+]

--- a/test/projects/extra_formatting/mix.exs
+++ b/test/projects/extra_formatting/mix.exs
@@ -1,0 +1,25 @@
+defmodule ExtraFormatting.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :extra_formatting,
+      version: "0.1.0",
+      elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:uniform, path: "../../../"}
+    ]
+  end
+end

--- a/test/projects/extra_formatting/mix.lock
+++ b/test/projects/extra_formatting/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "sourceror": {:hex, :sourceror, "0.14.0", "b6b8552d0240400d66b6f107c1bab7ac1726e998efc797f178b7b517e928e314", [:mix], [], "hexpm", "809c71270ad48092d40bbe251a133e49ae229433ce103f762a2373b7a10a8d8b"},
+}

--- a/test/uniform_test.exs
+++ b/test/uniform_test.exs
@@ -14,7 +14,7 @@ defmodule UniformTest do
 
   test "ejectable_apps/0" do
     command =
-      "Uniform.ejectable_apps() |> hd() |> Map.delete(:__struct__) |> inspect() |> IO.puts()"
+      "Uniform.ejectable_apps() |> hd() |> Map.delete(:__struct__) |> inspect(limit: :infinity, printable_limit: :infinity) |> IO.puts()"
 
     {stdout, 0} = System.cmd("mix", ["run", "-e", command])
     {map, []} = Code.eval_string(stdout)


### PR DESCRIPTION
- Prints full `app.extra` during output
- Introduces a test fixture app with a large uniform.exs config to test this change.